### PR TITLE
Add terms of usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # publications
+
+This repository contains a set of personal publications, anyone may read and use under the terms of this license:
+
+**CC BY (Creative Commons Attribution 4.0 International)**
+
+Your can find the license at: https://creativecommons.org/licenses/by/4.0/legalcode
+
+You can find a summery of the license at: https://creativecommons.org/licenses/by/4.0/
+
+
+All information provided has been carefully checked for accuracy. Nevertheless no guarantee can be given for the correctness, exactness, completeness, and appropriateness, neither in an explicit nor implicit form.
+ 
+**Author: Ralf Spengler**


### PR DESCRIPTION
- Decided to use "CC BY" because it supports spreading the
  information.
- Decided against "CC BY-ND" because it may be a hindrance
  for the media.